### PR TITLE
Make zero Fuse value usable

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
+    - name: Test
+      run: go test -v -race ./...

--- a/fuse_test.go
+++ b/fuse_test.go
@@ -6,23 +6,51 @@ import (
 )
 
 func TestFuse(t *testing.T) {
-	var f Fuse
-
-	onceStarted := make(chan struct{})
-	onceFinished := make(chan struct{})
-	go func() {
-		f.Once(func() {
-			close(onceStarted)
-			time.Sleep(time.Second)
-			close(onceFinished)
-		})
-	}()
-
-	<-onceStarted
-	f.Break()
-	select {
-	case <-onceFinished:
-	default:
-		t.Fail()
+	runOnce := func(f *Fuse) <-chan struct{} {
+		onceStarted := make(chan struct{})
+		onceFinished := make(chan struct{})
+		if f.IsBroken() {
+			t.Fail()
+		}
+		go func() {
+			f.Once(func() {
+				close(onceStarted)
+				time.Sleep(time.Second / 2)
+				close(onceFinished)
+			})
+		}()
+		<-onceStarted
+		if f.IsBroken() {
+			t.Fail()
+		}
+		return onceFinished
 	}
+	t.Run("break waits for once", func(t *testing.T) {
+		var f Fuse
+		onceFinished := runOnce(&f)
+
+		f.Break()
+		if !f.IsBroken() {
+			t.Fail()
+		}
+		select {
+		case <-onceFinished:
+		default:
+			t.Fatal("break doest wait for once to complete")
+		}
+	})
+	t.Run("can get channel early", func(t *testing.T) {
+		var f Fuse
+		done := f.Watch()
+
+		<-runOnce(&f)
+		if !f.IsBroken() {
+			t.Fail()
+		}
+		select {
+		case <-done:
+		default:
+			t.Fatal("watched channel not closed after once")
+		}
+	})
 }

--- a/fuse_test.go
+++ b/fuse_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestFuse(t *testing.T) {
-	f := NewFuse()
+	var f Fuse
 
 	onceStarted := make(chan struct{})
 	onceFinished := make(chan struct{})

--- a/pool.go
+++ b/pool.go
@@ -43,8 +43,6 @@ func NewQueuePool(params QueueWorkerParams) QueuePool {
 	return &queuePool{
 		workers: make(map[string]QueueWorker),
 		params:  params,
-		drain:   NewFuse(),
-		kill:    NewFuse(),
 	}
 }
 
@@ -115,9 +113,6 @@ func NewQueueWorker(params QueueWorkerParams) QueueWorker {
 		QueueWorkerParams: params,
 		next:              make(chan func(), 1),
 		deque:             deque.New[func()](params.QueueSize),
-		draining:          NewFuse(),
-		done:              NewFuse(),
-		kill:              NewFuse(),
 	}
 	go w.run()
 	return w

--- a/throttle_test.go
+++ b/throttle_test.go
@@ -25,11 +25,11 @@ func TestThrottle(t *testing.T) {
 	throttler(func() { c += 5 })
 	require.Equal(t, 17, c)
 
-	time.Sleep(time.Millisecond * 30)
+	time.Sleep(time.Millisecond * 40)
 	// function 3 executes
 	require.Equal(t, 22, c)
 
-	time.Sleep(time.Millisecond * 110)
+	time.Sleep(time.Millisecond * 100)
 	// ready
 
 	// executes immediately

--- a/throttle_test.go
+++ b/throttle_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -9,43 +10,55 @@ import (
 
 func TestThrottle(t *testing.T) {
 	throttler := NewThrottle(time.Millisecond * 100)
-	var c int
+	var c uint32
+	add := func(v int) {
+		atomic.AddUint32(&c, uint32(v))
+	}
+	get := func() int {
+		return int(atomic.LoadUint32(&c))
+	}
 
 	// executes immediately
-	throttler(func() { c += 17 })
-	require.Equal(t, 17, c)
+	throttler(func() { add(17) })
+	require.Equal(t, 17, get())
 
 	time.Sleep(time.Millisecond * 50)
 	// queued - 50ms remaining
-	throttler(func() { c += 1 })
-	require.Equal(t, 17, c)
+	throttler(func() { add(1) })
+	require.Equal(t, 17, get())
 
 	time.Sleep(time.Millisecond * 20)
 	// queued - 30ms remaining (overwrites function 2)
-	throttler(func() { c += 5 })
-	require.Equal(t, 17, c)
+	throttler(func() { add(5) })
+	require.Equal(t, 17, get())
 
 	time.Sleep(time.Millisecond * 40)
 	// function 3 executes
-	require.Equal(t, 22, c)
+	require.Equal(t, 22, get())
 
 	time.Sleep(time.Millisecond * 100)
 	// ready
 
 	// executes immediately
-	throttler(func() { c += 4 })
-	require.Equal(t, 26, c)
+	throttler(func() { add(4) })
+	require.Equal(t, 26, get())
 }
 
 func TestThrottleAsync(t *testing.T) {
 	throttler := NewThrottle(time.Millisecond * 100)
-	var c int
+	var c uint32
+	add := func(v int) {
+		atomic.AddUint32(&c, uint32(v))
+	}
+	get := func() int {
+		return int(atomic.LoadUint32(&c))
+	}
 
 	// executes immediately
 	throttler(func() {
 		go func() {
 			time.Sleep(time.Millisecond * 150)
-			c += 17
+			add(17)
 		}()
 	})
 
@@ -54,7 +67,7 @@ func TestThrottleAsync(t *testing.T) {
 	throttler(func() {
 		go func() {
 			time.Sleep(time.Millisecond * 100)
-			c += 1
+			add(1)
 		}()
 	})
 
@@ -63,7 +76,7 @@ func TestThrottleAsync(t *testing.T) {
 	throttler(func() {
 		go func() {
 			time.Sleep(time.Millisecond * 50)
-			c += 5
+			add(5)
 		}()
 	})
 
@@ -72,11 +85,11 @@ func TestThrottleAsync(t *testing.T) {
 	throttler(func() {
 		go func() {
 			time.Sleep(time.Millisecond * 150)
-			c += 4
+			add(4)
 		}()
 	})
 
 	// wait for function 4
 	time.Sleep(time.Millisecond * 160)
-	require.Equal(t, 26, c)
+	require.Equal(t, 26, get())
 }


### PR DESCRIPTION
Zero value of standard synchronization primitives like `sync.Mutex` and `sync.WaitGroup` are valid. One may expect similar behavior from `core.Fuse`, where it can be added as a struct field and used without additional initialization.

This change makes `Fuse` a struct and updates the logic to allow using zero values. Unfortunately due to the change from interface to struct, the change is breaking (requires to remove the constructor or field type).